### PR TITLE
Add german translation of netzmacht_workflow.en.xliff

### DIFF
--- a/src/Resources/contao/languages/en/tl_workflow_step.php
+++ b/src/Resources/contao/languages/en/tl_workflow_step.php
@@ -23,7 +23,7 @@ $GLOBALS['TL_LANG']['tl_workflow_step']['edit'][0]   = 'Edit step settings';
 $GLOBALS['TL_LANG']['tl_workflow_step']['edit'][1]   = 'Edit step ID "%s" settings';
 $GLOBALS['TL_LANG']['tl_workflow_step']['show'][0]   = 'Show step details';
 $GLOBALS['TL_LANG']['tl_workflow_step']['show'][1]   = 'Step details';
-$GLOBALS['TL_LANG']['tl_workflow_step']['delete'][0] = 'Delte step';
+$GLOBALS['TL_LANG']['tl_workflow_step']['delete'][0] = 'Delete step';
 $GLOBALS['TL_LANG']['tl_workflow_step']['delete'][1] = 'Delete step ID "%s"';
 
 /*

--- a/src/Resources/translations/netzmacht_workflow.de.xliff
+++ b/src/Resources/translations/netzmacht_workflow.de.xliff
@@ -1,0 +1,119 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="src/Resources/translations/netzmacht_workflow.en.xlf">
+        <body>
+            <trans-unit id="workflowName">
+                <source>workflowName</source>
+                <target>Workflow</target>
+            </trans-unit>
+            <trans-unit id="currentStep">
+                <source>currentStep</source>
+                <target>Aktueller Schritt</target>
+            </trans-unit>
+            <trans-unit id="reachedAt">
+                <source>reachedAt</source>
+                <target>Zuletzt geändert</target>
+            </trans-unit>
+            <trans-unit id="entity">
+                <source>dataRecord</source>
+                <target>Datensatz</target>
+            </trans-unit>
+            <trans-unit id="history">
+                <source>history</source>
+                <target>Verlauf</target>
+            </trans-unit>
+            <trans-unit id="history.start">
+                <source>history.start</source>
+                <target>Workflow</target>
+            </trans-unit>
+            <trans-unit id="history.transition">
+                <source>history.transition</source>
+                <target>Transition</target>
+            </trans-unit>
+            <trans-unit id="history.target">
+                <source>history.target</source>
+                <target>Ziel</target>
+            </trans-unit>
+            <trans-unit id="history.successful">
+                <source>history.successful</source>
+                <target>Erfolgreich</target>
+            </trans-unit>
+            <trans-unit id="history.reachedAt">
+                <source>history.reachedAt</source>
+                <target>Zuletzt geändert</target>
+            </trans-unit>
+            <trans-unit id="successful.yes">
+                <source>successful.yes</source>
+                <target>Ja</target>
+            </trans-unit>
+            <trans-unit id="successful.no">
+                <source>successful.no</source>
+                <target>Nein</target>
+            </trans-unit>
+            <trans-unit id="history.user">
+                <source>history.user</source>
+                <target>Benutzer</target>
+            </trans-unit>
+            <trans-unit id="history.scope">
+                <source>history.scope</source>
+                <target>Geltungsbereich</target>
+            </trans-unit>
+            <trans-unit id="history.scope.backend">
+                <source>history.scope.backend</source>
+                <target>Backend</target>
+            </trans-unit>
+            <trans-unit id="history.scope.frontend">
+                <source>history.scope.frontend</source>
+                <target>Frontend</target>
+            </trans-unit>
+            <trans-unit id="integration.legend">
+                <source>integration.legend</source>
+                <target>Workflow</target>
+            </trans-unit>
+            <trans-unit id="integration.operation.0">
+                <source>integration.operation.0</source>
+                <target>Workflow Übersicht</target>
+            </trans-unit>
+            <trans-unit id="integration.operation.1">
+                <source>integration.operation.1</source>
+                <target>Zeige die Workflow Übersicht für ID "%s"</target>
+            </trans-unit>
+            <trans-unit id="integration.workflow.0">
+                <source>integration.workflow.0</source>
+                <target>Workflow</target>
+            </trans-unit>
+            <trans-unit id="integration.workflow.1">
+                <source>integration.workflow.1</source>
+                <target>Bitte wählen Sie einen Workflow aus.</target>
+            </trans-unit>
+            <trans-unit id="integration.current_step.0">
+                <source>integration.current_step.0</source>
+                <target>Aktueller Schritt</target>
+            </trans-unit>
+            <trans-unit id="integration.current_step.1">
+                <source>integration.current_step.1</source>
+                <target>Aktueller Schritt des Workflows.</target>
+            </trans-unit>
+            <trans-unit id="transition.condition.expression.failed">
+                <source>transition.action.failed</source>
+                <target>Transitionsaktion fehlgeschagen: exception</target>
+            </trans-unit>
+            <trans-unit id="transition.condition.property.failed">
+                <source>transition.condition.property.failed</source>
+                <target>Bedingung für Eigenschaft %property% nicht erfüllt. %expected_value% wurde erwartet, aber %value% mit Operator %operator% ist gegeben.</target>
+            </trans-unit>
+            <trans-unit id="transition.condition.step_permission.not_started">
+                <source>transition.condition.step_permission.not_started</source>
+                <target>Workflow ist nicht gestartet. Berechtigungen konnten nicht geprüft werden.</target>
+            </trans-unit>
+            <trans-unit id="transition.condition.step_permission.failed">
+                <source>transition.condition.step_permission.failed</source>
+                <target>Schritt "%step%" hat nicht die benötigten Berechtigungen "%s".</target>
+            </trans-unit>
+            <trans-unit id="transition.condition.transition_permission.failed">
+                <source>transition.condition.transition_permission.failed</source>
+                <target>Die Berechtigung "%permission%" ist für die Transistion "%transition%" erforderlich.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
I added a german translation of netzmacht_workflow.en.xliff. I felt like some terms should not be translated, like `workflow` or `transition` as the translation might not be  as precise as the english term.